### PR TITLE
add public/js/out to gitignore

### DIFF
--- a/resources/leiningen/new/reagent_frontend/gitignore
+++ b/resources/leiningen/new/reagent_frontend/gitignore
@@ -9,6 +9,7 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /resources/public/js
+/public/js/out
 /out
 /.repl
 *.log


### PR DESCRIPTION
In development, figwheel is using public/js/out to store all the hundreds of files the compiler generates when one isn't using advanced compilation (or, at least, it's doing so for me).  This is just a trivial PR to fix the default .gitignore to keep that stuff out of version control.  (Leaving off the core app.js file, because I can imagine situations where someone might want to version that.)
