### PR TITLE
Set http root of figwheel to public folder.

### DIFF
--- a/resources/leiningen/new/reagent_frontend/project.clj
+++ b/resources/leiningen/new/reagent_frontend/project.clj
@@ -20,7 +20,7 @@
 
   :resource-paths ["public"]
 
-  :figwheel {:http-server-root "public"
+  :figwheel {:http-server-root "."
              :nrepl-port 7002
              :nrepl-middleware ["cemerick.piggieback/wrap-cljs-repl"]
              :css-dirs ["public/css"]}
@@ -34,7 +34,9 @@
                          :asset-path   "js/out"
                          :source-map true
                          :optimizations :none
-                         :pretty-print  true}}
+                         :pretty-print  true}
+                        :figwheel
+                        {:open-urls ["http://localhost:3449/index.html"]}}
                        :release
                        {:source-paths ["src" "env/prod/cljs"]
                         :compiler


### PR DESCRIPTION
I found localhost:3449 doesn't server the page. README already mentioned open `public/index.html` will work.

But I hope this update will make things a little bit easier.

Cheers