### PR TITLE
Add /public/js to .gitignore

### DIFF
--- a/resources/leiningen/new/reagent_frontend/gitignore
+++ b/resources/leiningen/new/reagent_frontend/gitignore
@@ -9,7 +9,7 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /resources/public/js
-/public/js/out
+/public/js
 /out
 /.repl
 *.log


### PR DESCRIPTION
This, in particular, makes `/public/js/app.js` and `/public/js/release` ignored (the latter is generated by `lein package`).